### PR TITLE
Treat custom feedback urls as final.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2020-05-28, Version 2.0.0 (Stable), @andymoody
+* Custom feedback url's are now treated as relative from the root
+  rather than being prepended with the app.baseUrl automatically.
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ const app = hof({
 });
 ```
 
-#### Customising the feedback form step path (Optional, defaults to /feedback):
+#### Customising the feedback form step path (Optional, defaults to ${app.baseUrl}/feedback):
+
+Note that if setting a custom url for the feedback form the app.baseUrl will not be applied automatically.
 
 ```javascript
 app.use((req, res, next) => {

--- a/lib/set-feedback-return-url.js
+++ b/lib/set-feedback-return-url.js
@@ -2,10 +2,14 @@
 
 module.exports = superclass => class Behaviour extends superclass {
   locals(req, res) {
-    const feedbackUrl = res.locals.feedbackUrl || '/feedback';
-    if (req.path !== feedbackUrl) {
-      req.sessionModel.set('feedbackReturnPath', req.path);
+    const feedbackUrl = res.locals.feedbackUrl || (req.baseUrl ? `${req.baseUrl}/feedback` : '/feedback');
+    if (req.url !== feedbackUrl) {
+      req.sessionModel.set('feedbackReturnPath', {
+        baseUrl: req.baseUrl,
+        path: req.path,
+        url: req.url
+      });
     }
-    return Object.assign(super.locals(req, res), {'feedbackUrl': req.baseUrl + feedbackUrl});
+    return Object.assign(super.locals(req, res), {'feedbackUrl': feedbackUrl});
   }
 };

--- a/lib/submit-feedback.js
+++ b/lib/submit-feedback.js
@@ -41,10 +41,7 @@ module.exports = superclass => class extends superclass {
 
   getNextStep(req, res) {
     const feedbackReturnPath = req.sessionModel.get(this.feedbackReturnKey);
-    if (feedbackReturnPath) {
-      return req.baseUrl + feedbackReturnPath;
-    }
-    return super.getNextStep(req, res);
+    return feedbackReturnPath ? feedbackReturnPath.url : super.getNextStep(req, res);
   }
 
   getNext(req) {
@@ -53,10 +50,7 @@ module.exports = superclass => class extends superclass {
 
   getBackLink(req, res) {
     const feedbackReturnPath = req.sessionModel.get(this.feedbackReturnKey);
-    if (feedbackReturnPath) {
-      return req.baseUrl + feedbackReturnPath;
-    }
-    return super.getBackLink(req, res);
+    return feedbackReturnPath ? feedbackReturnPath.url : super.getBackLink(req, res);
   }
 
   _sendEmailViaNotify(notifyConfig, req) {
@@ -65,8 +59,9 @@ module.exports = superclass => class extends superclass {
       const feedbackEmail = emailConfig.emailAddress;
       const templateId = emailConfig.templateId;
       let values = {};
-      values = this._addOptional(values, emailConfig.includeBaseUrlAs, req.baseUrl);
-      values = this._addOptional(values, emailConfig.includeSourcePathAs, req.sessionModel.get(this.feedbackReturnKey));
+      const feedbackReturnPath = req.sessionModel.get(this.feedbackReturnKey);
+      values = this._addOptional(values, emailConfig.includeBaseUrlAs, feedbackReturnPath.baseUrl);
+      values = this._addOptional(values, emailConfig.includeSourcePathAs, feedbackReturnPath.path);
       values = _.reduce(
         _.map(
           emailConfig.fieldMappings,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-behaviour-feedback",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A hof plugin allow customisation of the linked feedback form and feedback form submission",
   "main": "index.js",
   "scripts": {

--- a/test/spec/spec.set-feedback-return-url.js
+++ b/test/spec/spec.set-feedback-return-url.js
@@ -24,20 +24,25 @@ describe('SetReturnUrl behaviour', () => {
     sinon.stub(BaseController.prototype, 'locals').returns(superLocals);
 
     describe('should set return path and feedback url if not the feedback url', () => {
-      let req = request({});
-      req.sessionModel = {
-        set: sinon.spy()
-      };
-      req.baseUrl = '/app-name';
-      req.path = '/some-page';
+      let req;
+      let res;
 
-      let res = response();
-      res.locals = {};
+      beforeEach(() => {
+        req = request({});
+        res = response();
+        req.baseUrl = '/app-name';
+        req.path = '/some-page';
+        req.url = req.baseUrl + req.path;
+        req.sessionModel = {
+          set: sinon.spy()
+        };
+        res.locals = {};
+      });
 
       it('should set the feedback return url', () => {
         setReturnUrl.locals(req, res);
         req.sessionModel.set.should.have.been.calledOnce
-                  .and.calledWithExactly('feedbackReturnPath', req.path);
+                  .and.calledWithExactly('feedbackReturnPath', { baseUrl: req.baseUrl, path: req.path, url: req.url });
       });
 
       it('should set the feedback url to default when none provided', () => {
@@ -45,18 +50,22 @@ describe('SetReturnUrl behaviour', () => {
         expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback'});
       });
 
+      it('should set the feedback url to default when no base url present', () => {
+        req.baseUrl = undefined;
+        const returned = setReturnUrl.locals(req, res);
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback'});
+      });
+
       it('should set the feedback url to the specified value when provided', () => {
         res.locals = res.locals || {};
         res.locals.feedbackUrl = '/feedback2';
         const returned = setReturnUrl.locals(req, res);
-        expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback2'});
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2'});
       });
     });
 
     describe('should not set return path if this is the feedback url', () => {
           let req = request({});
-          req.baseUrl = '/app-name';
-          req.path = '/feedback';
 
           let res = response();
           res.locals = {};
@@ -65,6 +74,10 @@ describe('SetReturnUrl behaviour', () => {
             req.sessionModel = {
               set: sinon.spy()
             };
+
+            req.baseUrl = '/app-name';
+            req.path = '/feedback';
+            req.url = req.baseUrl + req.path;
           });
 
           it('should not set the feedback return url when using the default', () => {
@@ -77,19 +90,20 @@ describe('SetReturnUrl behaviour', () => {
             res.locals = res.locals || {};
             res.locals.feedbackUrl = '/feedback2';
             req.path = '/feedback2';
+            req.baseUrl = undefined;
+            req.url = req.path;
             const returned = setReturnUrl.locals(req, res);
             req.sessionModel.set.should.not.have.been.called;
-            expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback2'});
+            expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2'});
           });
 
           it('should set the feedback return url when a custom feedback page is specified and we are accessing the default url', () => {
             res.locals = res.locals || {};
             res.locals.feedbackUrl = '/feedback2';
-            req.path = '/feedback';
             const returned = setReturnUrl.locals(req, res);
             req.sessionModel.set.should.have.been.calledOnce
-              .and.calledWithExactly('feedbackReturnPath', req.path);
-            expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback2'});
+              .and.calledWithExactly('feedbackReturnPath', { baseUrl: req.baseUrl, path: req.path, url: req.url });
+            expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2'});
           });
 
         });

--- a/test/spec/spec.submit-feedback.js
+++ b/test/spec/spec.submit-feedback.js
@@ -92,8 +92,9 @@ describe('SubmitFeedback behaviour', () => {
 
   describe('process with a valid email config', () => {
     const originatingPath = '/path';
+    const baseUrl = '/app';
     const values = {
-      feedbackReturnPath: originatingPath
+      feedbackReturnPath: { baseUrl: baseUrl, path: originatingPath, url: baseUrl + originatingPath }
     };
     let req = {
         log: sinon.spy(),
@@ -104,9 +105,8 @@ describe('SubmitFeedback behaviour', () => {
                 input3: 'Some email'
             }
         },
-        baseUrl: '/app',
+        baseUrl: baseUrl,
         sessionModel: {
-
             get: function(key) {
                 return values[key];
             }
@@ -245,9 +245,9 @@ describe('SubmitFeedback behaviour', () => {
        });
      Promise.resolve(nextCalled).should.eventually.equal(true);
      Promise.resolve(errorPassedToNext).should.eventually.satisfy(function(value) {
-            req.log.should.have.been.calledOnce.and.calledWithExactly('error', error);
-            return value === 'There was an error sending your feedback';
-        });
+         req.log.should.have.been.calledOnce.and.calledWithExactly('error', error);
+         return value === 'There was an error sending your feedback';
+     });
 
    });
 
@@ -293,7 +293,7 @@ describe('SubmitFeedback behaviour', () => {
         log: sinon.spy(),
         sessionModel: {
           get: function() {
-            return '/badgers3';
+            return { baseUrl: '/app', path: '/badgers3', url: '/app/badgers3' };
           }
         }
       };
@@ -331,7 +331,7 @@ describe('SubmitFeedback behaviour', () => {
         log: sinon.spy(),
         sessionModel: {
           get: function() {
-            return '/badgers3';
+            return { baseUrl: '/app', path: '/badgers3', url: '/app/badgers3' };
           }
         }
       };


### PR DESCRIPTION
* Do not add app.baseUrl to them.
* If there is no baseUrl then we are at the root context.