### PR TITLE
Treat custom feedback urls as final.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 2020-05-28, Version 2.0.0 (Stable), @andymoody
+* Custom feedback url's are now treated as relative from the root
+  rather than being prepended with the app.baseUrl automatically.
+* Source (and return) url info is now passed as a Base64 encoded request parameter 'f_t' rather than being stored in
+  the session. 
+* This means that we can utilize a single feedback page for multiple HOF forms.
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # hof-behaviour-feedback
 
-HOF behaviour allowing a custom feedback page to be deployed as part of the hof form, which will then be linked to as part of the banner.
+HOF behaviour allowing a custom feedback page to be deployed as part of the hof form, which will then be linked to as 
+part of the banner.
 
-When configured correctly the user will be taken to the custom feedback form, and redirected back to the page they came from when the form has been submitted. 
+When configured correctly the user will be taken to the custom feedback form, and redirected back to the page they came 
+from when the form has been submitted.
+
+It is possible to use a single feedback instance for multiple hof forms - e.g. by including it in a 'common' app with 
+no base url and setting a custom feedback url of '/feedback'.
 
 ## Installation
 
@@ -23,7 +28,9 @@ const app = hof({
 });
 ```
 
-#### Customising the feedback form step path (Optional, defaults to /feedback):
+#### Customising the feedback form step path (Optional, defaults to ${app.baseUrl}/feedback):
+
+Note that if setting a custom url for the feedback form the app.baseUrl will not be applied automatically.
 
 ```javascript
 app.use((req, res, next) => {

--- a/lib/relative-url.js
+++ b/lib/relative-url.js
@@ -2,10 +2,16 @@
 
 const feedbackReturnInfoParameter = 'f_t';
 
-module.exports = class Url {
+/**
+  Enforces use of relative URL's, prevents someone maliciously causing a user to be directed to a phishing
+  site from our feedback page.
+**/
+module.exports = class RelativeUrl {
   constructor(urlString) {
     this.url = new URL(urlString, 'http://www.example.com');
-    this.mickeyTake = urlString.toLowerCase().includes('www.example.com');
+    if (this.url.hostname !== 'www.example.com') {
+      throw Error('Only relative URLs are allowed in feedback configuration');
+    }
   }
 
   addParam(name, value) {
@@ -27,8 +33,6 @@ module.exports = class Url {
   }
 
   toString() {
-     return this.url.hostname === 'www.example.com' && !this.mickeyTake ?
-       this.url.pathname + this.url.search :
-       this.url.href;
+    return this.url.pathname + this.url.search;
   }
 };

--- a/lib/return-path-info.js
+++ b/lib/return-path-info.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const atob = require('atob');
+const btoa = require('btoa');
+const Url = require('./url');
+
+module.exports = class ReturnPathInfo {
+  constructor(baseUrl, path, url) {
+    // parse all of these badboys as a Url to ensure they're sensible values
+    this.baseUrl = baseUrl ? new Url(baseUrl).toString() : baseUrl;
+    this.path = path ? new Url(path).toString() : path;
+    this.url = url ? new Url(url).toString() : url;
+  }
+
+  toString() {
+     return btoa(JSON.stringify(this));
+  }
+};
+
+module.exports.decode = function decode(encoded) {
+  if (encoded) {
+    const decoded = JSON.parse(atob(encoded));
+    return new this(decoded.baseUrl, decoded.path, decoded.url);
+  }
+  return undefined;
+};

--- a/lib/return-path-info.js
+++ b/lib/return-path-info.js
@@ -2,14 +2,14 @@
 
 const atob = require('atob');
 const btoa = require('btoa');
-const Url = require('./url');
+const RelativeUrl = require('./relative-url');
 
 module.exports = class ReturnPathInfo {
   constructor(baseUrl, path, url) {
     // parse all of these badboys as a Url to ensure they're sensible values
-    this.baseUrl = baseUrl ? new Url(baseUrl).toString() : baseUrl;
-    this.path = path ? new Url(path).toString() : path;
-    this.url = url ? new Url(url).toString() : url;
+    this.baseUrl = baseUrl ? new RelativeUrl(baseUrl).toString() : baseUrl;
+    this.path = path ? new RelativeUrl(path).toString() : path;
+    this.url = url ? new RelativeUrl(url).toString() : url;
   }
 
   toString() {

--- a/lib/set-feedback-return-url.js
+++ b/lib/set-feedback-return-url.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Url = require('./url');
+const RelativeUrl = require('./relative-url');
 const ReturnPathInfo = require('./return-path-info');
 
 module.exports = superclass => class Behaviour extends superclass {
@@ -8,7 +8,7 @@ module.exports = superclass => class Behaviour extends superclass {
     let feedbackUrl = res.locals.feedbackUrl || (req.baseUrl ? `${req.baseUrl}/feedback` : '/feedback');
     if (req.url !== feedbackUrl) {
       const returnInfo = new ReturnPathInfo(req.baseUrl, req.path, req.originalUrl);
-      feedbackUrl = new Url(feedbackUrl).setFeedbackReturnInfo(returnInfo.toString()).toString();
+      feedbackUrl = new RelativeUrl(feedbackUrl).setFeedbackReturnInfo(returnInfo.toString()).toString();
     }
     return Object.assign(super.locals(req, res), {'feedbackUrl': feedbackUrl});
   }

--- a/lib/set-feedback-return-url.js
+++ b/lib/set-feedback-return-url.js
@@ -1,11 +1,15 @@
 'use strict';
 
+const Url = require('./url');
+const ReturnPathInfo = require('./return-path-info');
+
 module.exports = superclass => class Behaviour extends superclass {
   locals(req, res) {
-    const feedbackUrl = res.locals.feedbackUrl || '/feedback';
-    if (req.path !== feedbackUrl) {
-      req.sessionModel.set('feedbackReturnPath', req.path);
+    let feedbackUrl = res.locals.feedbackUrl || (req.baseUrl ? `${req.baseUrl}/feedback` : '/feedback');
+    if (req.url !== feedbackUrl) {
+      const returnInfo = new ReturnPathInfo(req.baseUrl, req.path, req.originalUrl);
+      feedbackUrl = new Url(feedbackUrl).setFeedbackReturnInfo(returnInfo.toString()).toString();
     }
-    return Object.assign(super.locals(req, res), {'feedbackUrl': req.baseUrl + feedbackUrl});
+    return Object.assign(super.locals(req, res), {'feedbackUrl': feedbackUrl});
   }
 };

--- a/lib/submit-feedback.js
+++ b/lib/submit-feedback.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const _ = require('lodash');
-const Url = require('./url');
+const RelativeUrl = require('./relative-url');
 const ReturnPathInfo = require('./return-path-info');
 
 module.exports = superclass => class extends superclass {
@@ -18,7 +18,7 @@ module.exports = superclass => class extends superclass {
   }
 
   configure(req, res, callback) {
-    req.form.options.returnPathInfo = ReturnPathInfo.decode(new Url(req.originalUrl).getFeedbackReturnInfo());
+    req.form.options.returnPathInfo = ReturnPathInfo.decode(new RelativeUrl(req.originalUrl).getFeedbackReturnInfo());
     callback();
   }
 

--- a/lib/submit-feedback.js
+++ b/lib/submit-feedback.js
@@ -3,17 +3,23 @@
 'use strict';
 
 const _ = require('lodash');
+const Url = require('./url');
+const ReturnPathInfo = require('./return-path-info');
 
 module.exports = superclass => class extends superclass {
 
   constructor(options) {
     super(options);
     this.feedbackConfig = options.feedbackConfig;
-    this.feedbackReturnKey = 'feedbackReturnPath';
     if (options.feedbackConfig && options.feedbackConfig.notify) {
       const NotifyClient = require('notifications-node-client').NotifyClient;
       this.notifyClient = new NotifyClient(options.feedbackConfig.notify.apiKey);
     }
+  }
+
+  configure(req, res, callback) {
+    req.form.options.returnPathInfo = ReturnPathInfo.decode(new Url(req.originalUrl).getFeedbackReturnInfo());
+    callback();
   }
 
   process(req, res, next) {
@@ -40,11 +46,8 @@ module.exports = superclass => class extends superclass {
   }
 
   getNextStep(req, res) {
-    const feedbackReturnPath = req.sessionModel.get(this.feedbackReturnKey);
-    if (feedbackReturnPath) {
-      return req.baseUrl + feedbackReturnPath;
-    }
-    return super.getNextStep(req, res);
+    const feedbackReturnPath = req.form.options.returnPathInfo;
+    return feedbackReturnPath && feedbackReturnPath.url ? feedbackReturnPath.url : super.getNextStep(req, res);
   }
 
   getNext(req) {
@@ -52,11 +55,8 @@ module.exports = superclass => class extends superclass {
   }
 
   getBackLink(req, res) {
-    const feedbackReturnPath = req.sessionModel.get(this.feedbackReturnKey);
-    if (feedbackReturnPath) {
-      return req.baseUrl + feedbackReturnPath;
-    }
-    return super.getBackLink(req, res);
+    const feedbackReturnPath = req.form.options.returnPathInfo;
+    return feedbackReturnPath && feedbackReturnPath.url ? feedbackReturnPath.url : super.getBackLink(req, res);
   }
 
   _sendEmailViaNotify(notifyConfig, req) {
@@ -65,8 +65,9 @@ module.exports = superclass => class extends superclass {
       const feedbackEmail = emailConfig.emailAddress;
       const templateId = emailConfig.templateId;
       let values = {};
-      values = this._addOptional(values, emailConfig.includeBaseUrlAs, req.baseUrl);
-      values = this._addOptional(values, emailConfig.includeSourcePathAs, req.sessionModel.get(this.feedbackReturnKey));
+      const feedbackReturnPath = req.form.options.returnPathInfo;
+      values = this._addOptional(values, emailConfig.includeBaseUrlAs, feedbackReturnPath.baseUrl);
+      values = this._addOptional(values, emailConfig.includeSourcePathAs, feedbackReturnPath.path);
       values = _.reduce(
         _.map(
           emailConfig.fieldMappings,

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const feedbackReturnInfoParameter = 'f_t';
+
+module.exports = class Url {
+  constructor(urlString) {
+    this.url = new URL(urlString, 'http://www.example.com');
+    this.mickeyTake = urlString.toLowerCase().includes('www.example.com');
+  }
+
+  addParam(name, value) {
+    this.url.searchParams.set(name, value);
+    return this;
+  }
+
+  setFeedbackReturnInfo(value) {
+    this.addParam(feedbackReturnInfoParameter, value);
+    return this;
+  }
+
+  getFeedbackReturnInfo() {
+    return this.getParam(feedbackReturnInfoParameter);
+  }
+
+  getParam(name) {
+    return this.url.searchParams.get(name);
+  }
+
+  toString() {
+     return this.url.hostname === 'www.example.com' && !this.mickeyTake ?
+       this.url.pathname + this.url.search :
+       this.url.href;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-behaviour-feedback",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A hof plugin allow customisation of the linked feedback form and feedback form submission",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,8 @@
   },
   "homepage": "https://github.com/UKHomeOfficeForms/hof-behaviour-feedback",
   "dependencies": {
+    "atob": "^2.1.2",
+    "btoa": "^1.2.1",
     "lodash": "^4.17.15",
     "notifications-node-client": "^4.7.3"
   },

--- a/test/spec/spec.set-feedback-return-url.js
+++ b/test/spec/spec.set-feedback-return-url.js
@@ -24,39 +24,68 @@ describe('SetReturnUrl behaviour', () => {
     sinon.stub(BaseController.prototype, 'locals').returns(superLocals);
 
     describe('should set return path and feedback url if not the feedback url', () => {
-      let req = request({});
-      req.sessionModel = {
-        set: sinon.spy()
-      };
-      req.baseUrl = '/app-name';
-      req.path = '/some-page';
+      let req;
+      let res;
 
-      let res = response();
-      res.locals = {};
-
-      it('should set the feedback return url', () => {
-        setReturnUrl.locals(req, res);
-        req.sessionModel.set.should.have.been.calledOnce
-                  .and.calledWithExactly('feedbackReturnPath', req.path);
+      beforeEach(() => {
+        req = request({});
+        res = response();
+        req.baseUrl = '/app-name';
+        req.path = '/some-page';
+        req.originalUrl = req.baseUrl + req.path;
+        req.sessionModel = {
+          set: sinon.spy()
+        };
+        res.locals = {};
       });
 
       it('should set the feedback url to default when none provided', () => {
         const returned = setReturnUrl.locals(req, res);
-        expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback'});
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback?f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UiLCJ1cmwiOiIvYXBwLW5hbWUvc29tZS1wYWdlIn0%3D'});
+      });
+
+      it('should set the feedback context when no base url present', () => {
+        req.baseUrl = undefined;
+        const returned = setReturnUrl.locals(req, res);
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback?f_t=eyJwYXRoIjoiL3NvbWUtcGFnZSIsInVybCI6Ii9hcHAtbmFtZS9zb21lLXBhZ2UifQ%3D%3D'});
+      });
+
+      it('should set the feedback context when no path present', () => {
+        req.path = undefined;
+        const returned = setReturnUrl.locals(req, res);
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback?f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwidXJsIjoiL2FwcC1uYW1lL3NvbWUtcGFnZSJ9'});
+      });
+
+      it('should set the feedback context when originalUrl present', () => {
+        req.originalUrl = undefined;
+        const returned = setReturnUrl.locals(req, res);
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback?f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UifQ%3D%3D'});
       });
 
       it('should set the feedback url to the specified value when provided', () => {
         res.locals = res.locals || {};
         res.locals.feedbackUrl = '/feedback2';
         const returned = setReturnUrl.locals(req, res);
-        expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback2'});
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2?f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UiLCJ1cmwiOiIvYXBwLW5hbWUvc29tZS1wYWdlIn0%3D'});
+      });
+
+      it('should handle other query parameters in relative url when provided', () => {
+        res.locals = res.locals || {};
+        res.locals.feedbackUrl = '/feedback2?badger=monkeys';
+        const returned = setReturnUrl.locals(req, res);
+        expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2?badger=monkeys&f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UiLCJ1cmwiOiIvYXBwLW5hbWUvc29tZS1wYWdlIn0%3D'});
+      });
+
+      it('should handle absolute url as feedback url', () => {
+        res.locals = res.locals || {};
+        res.locals.feedbackUrl = 'http://www.homeoffice.gov.ul/feedback2?badger=monkeys';
+        const returned = setReturnUrl.locals(req, res);
+        expect(returned).to.include({foo: 'bar', feedbackUrl: 'http://www.homeoffice.gov.ul/feedback2?badger=monkeys&f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UiLCJ1cmwiOiIvYXBwLW5hbWUvc29tZS1wYWdlIn0%3D'});
       });
     });
 
     describe('should not set return path if this is the feedback url', () => {
           let req = request({});
-          req.baseUrl = '/app-name';
-          req.path = '/feedback';
 
           let res = response();
           res.locals = {};
@@ -65,6 +94,10 @@ describe('SetReturnUrl behaviour', () => {
             req.sessionModel = {
               set: sinon.spy()
             };
+
+            req.baseUrl = '/app-name';
+            req.path = '/feedback';
+            req.url = req.baseUrl + req.path;
           });
 
           it('should not set the feedback return url when using the default', () => {
@@ -77,19 +110,19 @@ describe('SetReturnUrl behaviour', () => {
             res.locals = res.locals || {};
             res.locals.feedbackUrl = '/feedback2';
             req.path = '/feedback2';
+            req.baseUrl = undefined;
+            req.url = req.path;
             const returned = setReturnUrl.locals(req, res);
             req.sessionModel.set.should.not.have.been.called;
-            expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback2'});
+            expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2'});
           });
 
           it('should set the feedback return url when a custom feedback page is specified and we are accessing the default url', () => {
             res.locals = res.locals || {};
             res.locals.feedbackUrl = '/feedback2';
-            req.path = '/feedback';
             const returned = setReturnUrl.locals(req, res);
-            req.sessionModel.set.should.have.been.calledOnce
-              .and.calledWithExactly('feedbackReturnPath', req.path);
-            expect(returned).to.include({foo: 'bar', feedbackUrl: '/app-name/feedback2'});
+            req.sessionModel.set.should.not.have.been.called;
+            expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2?f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9mZWVkYmFjayIsInVybCI6Ii8ifQ%3D%3D'});
           });
 
         });

--- a/test/spec/spec.set-feedback-return-url.js
+++ b/test/spec/spec.set-feedback-return-url.js
@@ -76,11 +76,10 @@ describe('SetReturnUrl behaviour', () => {
         expect(returned).to.include({foo: 'bar', feedbackUrl: '/feedback2?badger=monkeys&f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UiLCJ1cmwiOiIvYXBwLW5hbWUvc29tZS1wYWdlIn0%3D'});
       });
 
-      it('should handle absolute url as feedback url', () => {
+      it('should throw an error if an absolute url is provided as a feedback url', () => {
         res.locals = res.locals || {};
-        res.locals.feedbackUrl = 'http://www.homeoffice.gov.ul/feedback2?badger=monkeys';
-        const returned = setReturnUrl.locals(req, res);
-        expect(returned).to.include({foo: 'bar', feedbackUrl: 'http://www.homeoffice.gov.ul/feedback2?badger=monkeys&f_t=eyJiYXNlVXJsIjoiL2FwcC1uYW1lIiwicGF0aCI6Ii9zb21lLXBhZ2UiLCJ1cmwiOiIvYXBwLW5hbWUvc29tZS1wYWdlIn0%3D'});
+        res.locals.feedbackUrl = 'http://www.homeoffice.gov.uk/feedback2?badger=monkeys';
+        expect(setReturnUrl.locals.bind(setReturnUrl, req, res)).to.throw('Only relative URLs are allowed in feedback configuration');
       });
     });
 


### PR DESCRIPTION
* Do not add app.baseUrl to them.
* If there is no baseUrl then we are at the root context.
* As this now allows for common feedback pages for multiple HOF apps
  we now need to store more details about the source of the request and
  can no longer put this in the session model.
  Thus we pass the return path info in a base64 encoded request param.