### PR TITLE
Prevent old values from showing up on form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2020-06-01, Version 2.0.1 (Stable), @andymoody
+* Remove stored errorValues when the feedback form is successfully submitted.
+
 ## 2020-05-28, Version 2.0.0 (Stable), @andymoody
 * Custom feedback url's are now treated as relative from the root
   rather than being prepended with the app.baseUrl automatically.

--- a/lib/submit-feedback.js
+++ b/lib/submit-feedback.js
@@ -41,7 +41,13 @@ module.exports = superclass => class extends superclass {
   }
 
   saveValues(req, res, callback) {
-    // do nothing, we don't want to save them
+    // we don't want to save ahy values, but we do want to strip any error values that are present
+    const errorValues = req.sessionModel.get('errorValues');
+    const fieldNames = _.keys(req.form.values);
+    if (errorValues) {
+      req.sessionModel.set('errorValues', _.omitBy(errorValues, (value, key) => _.includes(fieldNames, key)));
+    }
+
     return callback();
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-behaviour-feedback",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A hof plugin allow customisation of the linked feedback form and feedback form submission",
   "main": "index.js",
   "scripts": {

--- a/test/spec/spec.submit-feedback.js
+++ b/test/spec/spec.submit-feedback.js
@@ -342,14 +342,56 @@ describe('SubmitFeedback behaviour', () => {
   });
 
   describe('saveValues', () => {
-    it('should not save anything', () => {
-      const req = sinon.spy();
+    it('should not save any form values', () => {
+      const req = {
+        sessionModel: {
+          get: sinon.stub(),
+          set: sinon.spy()
+        },
+        form: {
+          values: {
+            something: 'some value'
+          }
+        }
+      };
       const res = sinon.spy();
       const callback = sinon.spy();
 
+      req.sessionModel.get.withArgs('errorValues').returns(undefined);
+
       submitFeedback.saveValues(req, res, callback);
 
-      req.should.not.have.been.called;
+      req.sessionModel.set.should.not.have.been.called;
+      res.should.not.have.been.called;
+      callback.should.have.been.calledOnce;
+    });
+
+    it('should erase any error values that are related to this form', () => {
+      const req = {
+        sessionModel: {
+          get: sinon.stub(),
+          set: sinon.spy()
+        },
+        form: {
+          values: {
+            something: 'some value',
+            badger: 'monkeys'
+          }
+        }
+      };
+      const res = sinon.spy();
+      const callback = sinon.spy();
+
+      req.sessionModel.get.withArgs('errorValues').returns({
+        something: 'a',
+        anotherThing: 'genius',
+        badger: 'b'
+      });
+
+      submitFeedback.saveValues(req, res, callback);
+
+      req.sessionModel.set.should.have.been.calledOnce
+        .and.calledWithExactly('errorValues', { anotherThing: 'genius' });
       res.should.not.have.been.called;
       callback.should.have.been.calledOnce;
     });


### PR DESCRIPTION
When submitting the form with an error the values get stored in
the session model as 'errorValues'. We need to erase them on
submitting the form successfully as otherwise they appear the next
time the form is accessed.