### PR TITLE
Don't send feedback after validation errors.

### DIFF
--- a/lib/submit-feedback.js
+++ b/lib/submit-feedback.js
@@ -22,11 +22,11 @@ module.exports = superclass => class extends superclass {
     callback();
   }
 
-  process(req, res, next) {
+  successHandler(req, res, next) {
     if (this.feedbackConfig) {
         this._sendEmailViaNotify(this.feedbackConfig.notify, req)
         .then(() => {
-            super.process(req, res, next);
+            super.successHandler(req, res, next);
         })
         .catch((err) => {
           req.log('error', err.message || err.error);
@@ -36,7 +36,7 @@ module.exports = superclass => class extends superclass {
         req.log('warn', 'Submit feedback behaviour specified but no feedback config provided.' +
                 'Did you forget to specify feedbackConfig as part of your step?'
         );
-        next();
+        super.successHandler(req, res, next);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-behaviour-feedback",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A hof plugin allow customisation of the linked feedback form and feedback form submission",
   "main": "index.js",
   "scripts": {

--- a/test/spec/spec.submit-feedback.js
+++ b/test/spec/spec.submit-feedback.js
@@ -95,250 +95,262 @@ describe('SubmitFeedback behaviour', () => {
     });
   });
 
-  describe('process with no valid config', () => {
-    it('should log and call next if there is no config', () => {
-      submitFeedback = new SubmitFeedback({
-        template: 'index',
-        fields: {
-          field1: {},
-          field2: {}
-        }
+  describe('successHandler', () => {
+
+    before(() => {
+      sinon.stub(Controller.prototype, 'successHandler').returns('/badgers2');
+    });
+
+    after(() => {
+      Controller.prototype.successHandler.restore();
+    });
+
+    describe('with no valid config', () => {
+      it('should log and call super.successHandler if there is no config', () => {
+        submitFeedback = new SubmitFeedback({
+          template: 'index',
+          fields: {
+            field1: {},
+            field2: {}
+          }
+        });
+        let next = sinon.spy();
+        let req = {
+            log: sinon.spy()
+        };
+        let res = sinon.stub();
+
+        submitFeedback.successHandler(req, res, next);
+
+        req.log.should.have.been.calledOnce
+          .and.calledWithExactly('warn', 'Submit feedback behaviour specified but no feedback config provided.' +
+            'Did you forget to specify feedbackConfig as part of your step?'
+          );
+        Controller.prototype.successHandler.should.have.been.calledOnce
+          .and.calledWithExactly(req, res, next);
       });
-      let next = sinon.spy();
-      let req = {
-          log: sinon.spy()
-      };
-      let res = sinon.stub();
 
-      submitFeedback.process(req, res, next);
+      it('should do nothing if there is no email config', () => {
+        let req = {
+            log: sinon.spy()
+        };
+        let res = sinon.stub();
+        let nextCalled = false;
+        let next = function() {
+            nextCalled = true;
+        };
+        submitFeedback.notifyClient.sendEmail = sinon.spy();
 
-      req.log.should.have.been.calledOnce
-        .and.calledWithExactly('warn', 'Submit feedback behaviour specified but no feedback config provided.' +
-          'Did you forget to specify feedbackConfig as part of your step?'
-        );
-      next.should.have.been.calledOnce;
+        submitFeedback.successHandler(req, res, next);
+
+        req.log.should.have.not.been.called;
+        submitFeedback.notifyClient.sendEmail.should.have.not.been.called;
+        Promise.resolve(nextCalled).should.eventually.equal(true);
+      });
     });
 
-    it('should do nothing if there is no email config', () => {
-      let req = {
-          log: sinon.spy()
+    describe('with a valid email config', () => {
+      const originatingPath = '/path';
+      const baseUrl = '/app';
+      let req;
+      const res = sinon.stub();
+      const templateId = 'badger';
+      const feedbackEmail = 'b@example.com';
+
+      let nextCalled;
+      let errorPassedToNext;
+
+      let next = function(err) {
+        nextCalled = true;
+        errorPassedToNext = err;
       };
-      let res = sinon.stub();
-      let nextCalled = false;
-      let next = function() {
-          nextCalled = true;
-      };
-      submitFeedback.notifyClient.sendEmail = sinon.spy();
 
-      submitFeedback.process(req, res, next);
-
-      req.log.should.have.not.been.called;
-      submitFeedback.notifyClient.sendEmail.should.have.not.been.called;
-      Promise.resolve(nextCalled).should.eventually.equal(true);
-    });
-  });
-
-  describe('process with a valid email config', () => {
-    const originatingPath = '/path';
-    const baseUrl = '/app';
-    let req;
-    const res = sinon.stub();
-    const templateId = 'badger';
-    const feedbackEmail = 'b@example.com';
-
-    let nextCalled;
-    let errorPassedToNext;
-
-    let next = function(err) {
-      nextCalled = true;
-      errorPassedToNext = err;
-    };
-
-    beforeEach(() => {
-      req = {
-        log: sinon.spy(),
-        form: {
-          values: {
-            input1: 'Some text',
-            input2: 'Some name',
-            input3: 'Some email'
+      beforeEach(() => {
+        req = {
+          log: sinon.spy(),
+          form: {
+            values: {
+              input1: 'Some text',
+              input2: 'Some name',
+              input3: 'Some email'
+            },
+            options: {
+              returnPathInfo: { baseUrl: baseUrl, path: originatingPath, url: baseUrl + originatingPath }
+            }
           },
-          options: {
-            returnPathInfo: { baseUrl: baseUrl, path: originatingPath, url: baseUrl + originatingPath }
+          baseUrl: baseUrl
+        };
+        nextCalled = false;
+        errorPassedToNext = undefined;
+      });
+
+      it('should send email according to configured inputs map if there is an email config', () => {
+        submitFeedback = new SubmitFeedback({
+          template: 'index',
+          fields: {
+            field1: {},
+            field2: {}
+          },
+          feedbackConfig: {
+            something: 'someValue',
+            notify: {
+               apiKey: apiKey,
+               email: {
+                 templateId: templateId,
+                 emailAddress: feedbackEmail,
+                 fieldMappings: {
+                   input1: 'feedback',
+                   input2: 'name',
+                   input3: 'email'
+                 },
+                 includeBaseUrlAs: 'process',
+                 includeSourcePathAs: 'path'
+               }
+            }
           }
-        },
-        baseUrl: baseUrl
-      };
-      nextCalled = false;
-      errorPassedToNext = undefined;
+        });
+
+        submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.resolve());
+
+        submitFeedback.successHandler(req, res, next);
+
+        submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
+          .and.calledWithExactly(templateId, feedbackEmail, {
+            personalisation: {
+              process: baseUrl,
+              path: originatingPath,
+              feedback: req.form.values.input1,
+              name: req.form.values.input2,
+              email: req.form.values.input3
+            }
+          });
+        Promise.resolve(nextCalled).should.eventually.equal(true);
+        expect(errorPassedToNext).to.be.an('undefined');
+     });
+
+      it('should send email with undefined baseUrl and path if they are not present', () => {
+        submitFeedback = new SubmitFeedback({
+          template: 'index',
+          fields: {
+            field1: {},
+            field2: {}
+          },
+          feedbackConfig: {
+            something: 'someValue',
+            notify: {
+               apiKey: apiKey,
+               email: {
+                 templateId: templateId,
+                 emailAddress: feedbackEmail,
+                 fieldMappings: {
+                   input1: 'feedback',
+                   input2: 'name',
+                   input3: 'email'
+                 },
+                 includeBaseUrlAs: 'process',
+                 includeSourcePathAs: 'path'
+               }
+            }
+          }
+        });
+        delete req.form.options.returnPathInfo.baseUrl;
+        delete req.form.options.returnPathInfo.path;
+
+        submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.resolve());
+
+        submitFeedback.successHandler(req, res, next);
+
+        submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
+          .and.calledWithExactly(templateId, feedbackEmail, {
+            personalisation: {
+              feedback: req.form.values.input1,
+              name: req.form.values.input2,
+              email: req.form.values.input3
+            }
+          });
+        Promise.resolve(nextCalled).should.eventually.equal(true);
+        expect(errorPassedToNext).to.be.an('undefined');
+     });
+
+     it('should ignore fields not explicitly mapped in the email config', () => {
+       submitFeedback = new SubmitFeedback({
+         template: 'index',
+         fields: {
+           field1: {},
+           field2: {}
+         },
+         feedbackConfig: {
+           something: 'someValue',
+           notify: {
+              apiKey: apiKey,
+              email: {
+                templateId: templateId,
+                emailAddress: feedbackEmail,
+                fieldMappings: {
+                  input2: 'name'
+                }
+              }
+           }
+         }
+       });
+
+       submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.resolve());
+
+       submitFeedback.successHandler(req, res, next);
+
+       submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
+         .and.calledWithExactly(templateId, feedbackEmail, {
+           personalisation: {
+             name: req.form.values.input2
+           }
+         });
+       Promise.resolve(nextCalled).should.eventually.equal(true);
+       expect(errorPassedToNext).to.be.an('undefined');
+     });
+
+     it('should call next logging the thrown error and returning a sensible user facing error if email sending fails',
+     () => {
+       submitFeedback = new SubmitFeedback({
+         template: 'index',
+         fields: {
+           field1: {},
+           field2: {}
+         },
+         feedbackConfig: {
+           something: 'someValue',
+           notify: {
+              apiKey: apiKey,
+              email: {
+                templateId: templateId,
+                emailAddress: feedbackEmail,
+                fieldMappings: {
+                  input2: 'name'
+                }
+              }
+           }
+         }
+       });
+
+       const error = 'some message';
+       submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.reject(error));
+
+       submitFeedback.successHandler(req, res, next);
+
+       submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
+         .and.calledWithExactly(templateId, feedbackEmail, {
+           personalisation: {
+             name: req.form.values.input2
+           }
+         });
+       Promise.resolve(nextCalled).should.eventually.equal(true);
+       Promise.resolve(errorPassedToNext).should.eventually.satisfy(function(value) {
+           req.log.should.have.been.calledOnce.and.calledWithExactly('error', error);
+           return value === 'There was an error sending your feedback';
+       });
+
+     });
+
     });
-
-    it('should send email according to configured inputs map if there is an email config', () => {
-      submitFeedback = new SubmitFeedback({
-        template: 'index',
-        fields: {
-          field1: {},
-          field2: {}
-        },
-        feedbackConfig: {
-          something: 'someValue',
-          notify: {
-             apiKey: apiKey,
-             email: {
-               templateId: templateId,
-               emailAddress: feedbackEmail,
-               fieldMappings: {
-                 input1: 'feedback',
-                 input2: 'name',
-                 input3: 'email'
-               },
-               includeBaseUrlAs: 'process',
-               includeSourcePathAs: 'path'
-             }
-          }
-        }
-      });
-
-      submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.resolve());
-
-      submitFeedback.process(req, res, next);
-
-      submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
-        .and.calledWithExactly(templateId, feedbackEmail, {
-          personalisation: {
-            process: baseUrl,
-            path: originatingPath,
-            feedback: req.form.values.input1,
-            name: req.form.values.input2,
-            email: req.form.values.input3
-          }
-        });
-      Promise.resolve(nextCalled).should.eventually.equal(true);
-      expect(errorPassedToNext).to.be.an('undefined');
-   });
-
-    it('should send email with undefined baseUrl and path if they are not present', () => {
-      submitFeedback = new SubmitFeedback({
-        template: 'index',
-        fields: {
-          field1: {},
-          field2: {}
-        },
-        feedbackConfig: {
-          something: 'someValue',
-          notify: {
-             apiKey: apiKey,
-             email: {
-               templateId: templateId,
-               emailAddress: feedbackEmail,
-               fieldMappings: {
-                 input1: 'feedback',
-                 input2: 'name',
-                 input3: 'email'
-               },
-               includeBaseUrlAs: 'process',
-               includeSourcePathAs: 'path'
-             }
-          }
-        }
-      });
-      delete req.form.options.returnPathInfo.baseUrl;
-      delete req.form.options.returnPathInfo.path;
-
-      submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.resolve());
-
-      submitFeedback.process(req, res, next);
-
-      submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
-        .and.calledWithExactly(templateId, feedbackEmail, {
-          personalisation: {
-            feedback: req.form.values.input1,
-            name: req.form.values.input2,
-            email: req.form.values.input3
-          }
-        });
-      Promise.resolve(nextCalled).should.eventually.equal(true);
-      expect(errorPassedToNext).to.be.an('undefined');
-   });
-
-   it('should ignore fields not explicitly mapped in the email config', () => {
-     submitFeedback = new SubmitFeedback({
-       template: 'index',
-       fields: {
-         field1: {},
-         field2: {}
-       },
-       feedbackConfig: {
-         something: 'someValue',
-         notify: {
-            apiKey: apiKey,
-            email: {
-              templateId: templateId,
-              emailAddress: feedbackEmail,
-              fieldMappings: {
-                input2: 'name'
-              }
-            }
-         }
-       }
-     });
-
-     submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.resolve());
-
-     submitFeedback.process(req, res, next);
-
-     submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
-       .and.calledWithExactly(templateId, feedbackEmail, {
-         personalisation: {
-           name: req.form.values.input2
-         }
-       });
-     Promise.resolve(nextCalled).should.eventually.equal(true);
-     expect(errorPassedToNext).to.be.an('undefined');
-   });
-
-   it('should call next logging the thrown error and returning a sensible user facing error if email sending fails',
-   () => {
-     submitFeedback = new SubmitFeedback({
-       template: 'index',
-       fields: {
-         field1: {},
-         field2: {}
-       },
-       feedbackConfig: {
-         something: 'someValue',
-         notify: {
-            apiKey: apiKey,
-            email: {
-              templateId: templateId,
-              emailAddress: feedbackEmail,
-              fieldMappings: {
-                input2: 'name'
-              }
-            }
-         }
-       }
-     });
-
-     const error = 'some message';
-     submitFeedback.notifyClient.sendEmail = sinon.fake.returns(Promise.reject(error));
-
-     submitFeedback.process(req, res, next);
-
-     submitFeedback.notifyClient.sendEmail.should.have.been.calledOnce
-       .and.calledWithExactly(templateId, feedbackEmail, {
-         personalisation: {
-           name: req.form.values.input2
-         }
-       });
-     Promise.resolve(nextCalled).should.eventually.equal(true);
-     Promise.resolve(errorPassedToNext).should.eventually.satisfy(function(value) {
-         req.log.should.have.been.calledOnce.and.calledWithExactly('error', error);
-         return value === 'There was an error sending your feedback';
-     });
-
-   });
-
   });
 
   describe('saveValues', () => {


### PR DESCRIPTION
* Change process override to successHandler override.
* Use super.successHandler when successful, and call next with the
error otherwise.